### PR TITLE
#73 Added generic auth provider support

### DIFF
--- a/exasol/ai/mcp/server/generic_auth.py
+++ b/exasol/ai/mcp/server/generic_auth.py
@@ -1,0 +1,188 @@
+"""
+This module allows to create and use one of generic OAuth providers included in FastMCP.
+
+FastMCP also supports a number of specific identity providers, e.g. Google or Auth0.
+It offers a mechanism of configuring one of these providers using a set of defined
+environment variables. The selection of the provider the MCP server is configured with
+is defined in the environment variable FASTMCP_SERVER_AUTH.
+
+For some reason FastMCP chose not to extend this mechanism on their generic providers.
+This module does just that. It allows configuring one the three providers - JWTVerifier,
+OAuthProxy, RemoteAuthProvider. To be precise, JWTVerifier can be configured using the
+FastMCP environment variables, but because it is a part of the other two it is included
+here as well. All optional parameters of these providers are supported, without giving
+much thought on their usefulness in our use case.
+
+If at any point in time FastMCP defines environment variables for the generic providers,
+this module can be retired.
+
+We deliberately use our own prefixes in the names of environment variables. If FastMCP
+defines environment variables for the generic providers they can be used immediately
+without waiting for this module to be removed.
+"""
+
+import csv
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from io import StringIO
+from typing import (
+    Any,
+    Type,
+)
+
+from fastmcp.server.auth import (
+    AuthProvider,
+    OAuthProxy,
+    RemoteAuthProvider,
+)
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+ENV_PROVIDER_TYPE = "FASTMCP_SERVER_AUTH"
+
+
+def str_to_list(s) -> list[str]:
+    s = s.replace("\n", " ")
+    reader = csv.reader(StringIO(s), skipinitialspace=True)
+    fields = next(reader)
+    return [fld.strip() for fld in fields if fld.strip()]
+
+
+def str_to_str(s: str) -> str:
+    fields = str_to_list(s)
+    if fields:
+        return fields[0]
+    return ""
+
+
+def str_to_bool(s) -> bool:
+    s_lower = str_to_str(s).lower()
+    if s_lower == "true":
+        return True
+    if s_lower == "false":
+        return False
+    raise ValueError(f"Invalid boolean parameter: {s}")
+
+
+def str_to_dict(s) -> dict[str, str]:
+    fields = str_to_list(s)
+    if (len(fields) % 2) != 0:
+        raise ValueError(
+            f"Invalid dictionary parameter: {s}. "
+            "The dictionary must be provided as a plain list of keys and values."
+        )
+    return {fields[i]: fields[i + 1] for i in range(0, len(fields) - 1, 2)}
+
+
+@dataclass
+class AuthParameter:
+    name: str
+    conv: Callable[[str], Any] = lambda v: str_to_str(v)
+
+
+@dataclass
+class AuthProviderInfo:
+    provider_type: type[AuthProvider]
+    parameters: list[AuthParameter]
+
+
+_generic_providers = [
+    AuthProviderInfo(
+        provider_type=JWTVerifier,
+        parameters=[
+            AuthParameter("public_key"),
+            AuthParameter("jwks_uri"),
+            AuthParameter("issuer"),
+            AuthParameter("audience", str_to_list),
+            AuthParameter("algorithm"),
+            AuthParameter("required_scopes", str_to_list),
+            AuthParameter("base_url"),
+        ],
+    ),
+    AuthProviderInfo(
+        provider_type=RemoteAuthProvider,
+        parameters=[
+            AuthParameter("authorization_servers", str_to_list),
+            AuthParameter("base_url"),
+            AuthParameter("resource_name"),
+            AuthParameter("resource_documentation"),
+        ],
+    ),
+    AuthProviderInfo(
+        provider_type=OAuthProxy,
+        parameters=[
+            AuthParameter("upstream_authorization_endpoint"),
+            AuthParameter("upstream_token_endpoint"),
+            AuthParameter("upstream_client_id"),
+            AuthParameter("upstream_client_secret"),
+            AuthParameter("upstream_revocation_endpoint"),
+            AuthParameter("base_url"),
+            AuthParameter("redirect_path"),
+            AuthParameter("issuer_url"),
+            AuthParameter("service_documentation_url"),
+            AuthParameter("allowed_client_redirect_uris", str_to_list),
+            AuthParameter("valid_scopes", str_to_list),
+            AuthParameter("forward_pkce", str_to_bool),
+            AuthParameter("token_endpoint_auth_method"),
+            AuthParameter("extra_authorize_params", str_to_dict),
+            AuthParameter("extra_token_params", str_to_dict),
+        ],
+    ),
+]
+
+
+def exa_provider_name(provider_type: type[AuthProvider]) -> str:
+    return f"exa.{provider_type.__module__}.{provider_type.__qualname__}"
+
+
+def exa_parameter_env_name(param: AuthParameter) -> str:
+    # We don't use the class name in the environment variable names. In the future,
+    # this can potentially create a name clash between the parameters of JWTVerifier
+    # and either OAuthProxy or RemoteAuthProvider. This is very unlikely though,
+    # and we will deal with if and when it happens.
+    return f"EXA_AUTH_{param.name.upper()}"
+
+
+def create_auth_provider(
+    provider_info: AuthProviderInfo, **extra_kwargs
+) -> AuthProvider:
+    kwargs = {
+        param.name: param.conv(os.environ[exa_parameter_env_name(param)])
+        for param in provider_info.parameters
+        if exa_parameter_env_name(param) in os.environ
+    }
+    return provider_info.provider_type(**kwargs, **extra_kwargs)
+
+
+def get_auth_provider() -> AuthProvider | None:
+    """
+    Creates one of FastMCP generic OAuth2 providers, if the correspondent type name is
+    set in the FASTMCP_SERVER_AUTH environment variable.
+    """
+    provider_name = os.environ.get("FASTMCP_SERVER_AUTH")
+    if not provider_name:
+        return None
+
+    provider_map = {
+        exa_provider_name(provider.provider_type): provider
+        for provider in _generic_providers
+    }
+    if provider_name not in provider_map:
+        return None
+
+    verifier_name = exa_provider_name(JWTVerifier)
+    verifier = create_auth_provider(provider_map[verifier_name])
+    if provider_name == verifier_name:
+        return verifier
+    return create_auth_provider(provider_map[provider_name], token_verifier=verifier)
+
+
+def get_auth_kwargs() -> dict[str, AuthProvider]:
+    """
+    A helper function that builds kwargs with an optional `auth` parameter,
+    to be used in the MCP server constructor.
+    """
+    provider = get_auth_provider()
+    if provider is None:
+        return {}
+    return {"auth": provider}

--- a/test/unit/test_generic_auth.py
+++ b/test/unit/test_generic_auth.py
@@ -1,0 +1,189 @@
+import pytest
+from fastmcp.server.auth import (
+    AuthProvider,
+    OAuthProxy,
+    RemoteAuthProvider,
+)
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+from exasol.ai.mcp.server.generic_auth import (
+    ENV_PROVIDER_TYPE,
+    AuthParameter,
+    AuthProviderInfo,
+    create_auth_provider,
+    exa_parameter_env_name,
+    exa_provider_name,
+    get_auth_kwargs,
+    get_auth_provider,
+    str_to_bool,
+    str_to_dict,
+    str_to_list,
+    str_to_str,
+)
+
+
+class FakeAuthProvider(AuthProvider):
+    # pylint: disable=super-init-not-called
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def fake_provider_info() -> AuthProviderInfo:
+    return AuthProviderInfo(
+        provider_type=FakeAuthProvider,
+        parameters=[
+            AuthParameter("str_param"),
+            AuthParameter("bool_param", str_to_bool),
+            AuthParameter("list_param", str_to_list),
+            AuthParameter("dict_param", str_to_dict),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ["input_str", "expected_str"],
+    [
+        ("  ", ""),
+        (" abc ", "abc"),
+        (' " abc " ', "abc"),
+        ('a"bc', 'a"bc'),
+        ('"a""bc"', 'a"bc'),
+        ('"a""""bc"', 'a""bc'),
+    ],
+)
+def test_str_to_str(input_str, expected_str):
+    assert str_to_str(input_str) == expected_str
+
+
+@pytest.mark.parametrize(
+    ["input_str", "expected_bool"],
+    [
+        (" True ", True),
+        (" false", False),
+    ],
+)
+def test_str_to_bool(input_str, expected_bool):
+    assert str_to_bool(input_str) == expected_bool
+
+
+def test_str_to_bool_error():
+    with pytest.raises(ValueError, match="Invalid boolean parameter"):
+        str_to_bool("yes")
+
+
+@pytest.mark.parametrize(
+    ["input_str", "expected_list"],
+    [
+        (" ", []),
+        ("abc", ["abc"]),
+        ("abc, def,g", ["abc", "def", "g"]),
+        ("abc, def\n,\ng", ["abc", "def", "g"]),
+        ('" a,bc ", "d""ef", """g""" ', ["a,bc", 'd"ef', '"g"']),
+    ],
+)
+def test_str_to_list(input_str, expected_list):
+    assert str_to_list(input_str) == expected_list
+
+
+@pytest.mark.parametrize(
+    ["input_str", "expected_dict"],
+    [
+        (" ", {}),
+        ("abc, def", {"abc": "def"}),
+        ("abc , def, gh, 5", {"abc": "def", "gh": "5"}),
+        ("abc , def,\ngh,5", {"abc": "def", "gh": "5"}),
+        ('"abc", "def""", g, "h,f"', {"abc": 'def"', "g": "h,f"}),
+    ],
+)
+def test_str_to_dict(input_str, expected_dict):
+    assert str_to_dict(input_str) == expected_dict
+
+
+def test_str_to_dict_error():
+    with pytest.raises(ValueError, match="Invalid dictionary parameter"):
+        str_to_dict("abc, def, ghf")
+
+
+def test_exa_provider_name() -> None:
+    assert (
+        exa_provider_name(FakeAuthProvider) == "exa.test_generic_auth.FakeAuthProvider"
+    )
+
+
+def test_exa_parameter_env_name() -> None:
+    assert exa_parameter_env_name(AuthParameter("abc")) == "EXA_AUTH_ABC"
+
+
+@pytest.mark.parametrize(
+    ["params", "extra_kwargs", "expected_kwargs"],
+    [
+        (
+            {"str_param": "abc", "bool_param": "true"},
+            {"something_else": 777},
+            {"str_param": "abc", "bool_param": True, "something_else": 777},
+        ),
+        (
+            {"list_param": 'abc, "e,d"', "dict_param": "x, 1, y, 2"},
+            {},
+            {"list_param": ["abc", "e,d"], "dict_param": {"x": "1", "y": "2"}},
+        ),
+    ],
+    ids=["str_and_bool", "list_and_dict"],
+)
+def test_create_auth_provider(
+    fake_provider_info, monkeypatch, params, extra_kwargs, expected_kwargs
+) -> None:
+    for key, value in params.items():
+        monkeypatch.setenv(exa_parameter_env_name(AuthParameter(key)), value)
+    provider = create_auth_provider(fake_provider_info, **extra_kwargs)
+    assert isinstance(provider, FakeAuthProvider)
+    assert provider.kwargs == expected_kwargs
+
+
+@pytest.mark.parametrize(
+    ["provider_type", "params"],
+    [
+        (JWTVerifier, {"jwks_uri": "http://some_url:1234"}),
+        (
+            RemoteAuthProvider,
+            {
+                "jwks_uri": "http://some_url:1234",
+                "authorization_servers": "http://some_other_url:4321",
+                "base_url": "http://my_mcp_server",
+            },
+        ),
+        (
+            OAuthProxy,
+            {
+                "jwks_uri": "http://some_url:1234",
+                "upstream_authorization_endpoint": "http://auth_url",
+                "upstream_token_endpoint": "http://token_url",
+                "upstream_client_id": "some_client_id",
+                "upstream_client_secret": "some_client_secret",
+                "base_url": "http://my_mcp_server",
+            },
+        ),
+    ],
+    ids=["JWTVerifier", "RemoteAuthProvider", "OAuthProxy"],
+)
+def test_get_auth_provider(monkeypatch, provider_type, params) -> None:
+    monkeypatch.setenv(ENV_PROVIDER_TYPE, exa_provider_name(provider_type))
+    for key, value in params.items():
+        monkeypatch.setenv(exa_parameter_env_name(AuthParameter(key)), value)
+    provider = get_auth_provider()
+    assert isinstance(provider, provider_type)
+
+
+def test_get_auth_kwargs(monkeypatch) -> None:
+    monkeypatch.setenv(ENV_PROVIDER_TYPE, exa_provider_name(JWTVerifier))
+    monkeypatch.setenv(
+        exa_parameter_env_name(AuthParameter("jwks_uri")), "http://some_url:1234"
+    )
+    kwargs = get_auth_kwargs()
+    assert len(kwargs) == 1
+    assert isinstance(kwargs["auth"], JWTVerifier)
+
+
+def test_get_auth_kwargs_empty() -> None:
+    assert not get_auth_kwargs()


### PR DESCRIPTION
closes #73 

This PR enables all possible options for the DB authentication:
- password,
- externally provided access or refresh token,
- MCP OpenID.
In the first 3 options the MCP can still be protected with OpenID.
The OpenID can be configured to use:
- one of the providers included in FastMCP,
- one of the generic providers.
