### PR TITLE
#200: Add env-based config for key OAuth providers

### DIFF
--- a/doc/changes/unreleased.md
+++ b/doc/changes/unreleased.md
@@ -2,6 +2,12 @@
 
 ## Summary
 
+This release upgrades FastMCP to 3.2.4 to fix CVE-2026-32871. It restores FastMCP v2-compatible environment variable configuration for Auth0, AuthKit, AWS Cognito, Azure, and Google OAuth providers, but not for all availabe providers.
+
+## Features
+
+* #200: Restored FastMCP v2-compatible environment variable configuration for Auth0, AuthKit, AWS Cognito, Azure, and Google OAuth providers.
+
 ## Security
 
 * #192: Upgrade FastMCP to 3.2.4 to fix CVE-2026-32871

--- a/doc/user_guide/open_id_setup.rst
+++ b/doc/user_guide/open_id_setup.rst
@@ -53,10 +53,20 @@ At the time of writing, the following providers are supported:
 * `Google <https://gofastmcp.com/integrations/google>`__
 * `WorkOS <https://gofastmcp.com/integrations/workos>`__
 
+FastMCP v3 removed the automatic configuration of these specific providers from
+environment variables. Exasol MCP Server restores this capability for the
+following provider classes using the FastMCP v2-compatible variable names:
+
+* ``fastmcp.server.auth.providers.auth0.Auth0Provider``
+* ``fastmcp.server.auth.providers.aws.AWSCognitoProvider``
+* ``fastmcp.server.auth.providers.azure.AzureProvider``
+* ``fastmcp.server.auth.providers.google.GoogleProvider``
+* ``fastmcp.server.auth.providers.workos.AuthKitProvider``
+
 To configure the MCP authentication with any of these providers, please set the
-environment variables, as described in the FastMCP documentation for a particular
-provider. As an example, the following environment variables shall be set when
-working with AuthKit:
+environment variables as described in the FastMCP v2 documentation for a
+particular provider. As an example, the following environment variables shall be
+set when working with AuthKit:
 
 .. code-block:: shell
 
@@ -65,7 +75,8 @@ working with AuthKit:
     export FASTMCP_SERVER_AUTH_AUTHKITPROVIDER_BASE_URL=https://your-server.com
 
 Note that the ``FASTMCP_SERVER_AUTH`` should always be set to the module path of the
-provider's class.
+provider's class. The generic providers described below still use the Exasol-specific
+``EXA_AUTH_*`` environment variables.
 
 FastMCP Generic OAuth Providers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/exasol/ai/mcp/server/setup/generic_auth.py
+++ b/exasol/ai/mcp/server/setup/generic_auth.py
@@ -27,7 +27,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
 from io import StringIO
-from typing import Any, Literal
+from typing import (
+    Any,
+    Literal,
+)
 
 from fastmcp.server.auth import (
     AuthProvider,
@@ -38,8 +41,8 @@ from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.auth.providers.auth0 import Auth0Provider
 from fastmcp.server.auth.providers.aws import AWSCognitoProvider
 from fastmcp.server.auth.providers.azure import AzureProvider
-from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
 from fastmcp.server.auth.providers.google import GoogleProvider
+from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.auth.providers.workos import AuthKitProvider
 
@@ -177,9 +180,7 @@ _builtin_providers = [
             AuthParameter("required_scopes", str_to_list),
             AuthParameter("redirect_path"),
             AuthParameter("allowed_client_redirect_uris", str_to_list),
-            AuthParameter(
-                "require_authorization_consent", str_to_bool_or_external
-            ),
+            AuthParameter("require_authorization_consent", str_to_bool_or_external),
             AuthParameter("consent_csp_policy"),
             AuthParameter("forward_resource", str_to_bool),
         ],
@@ -199,9 +200,7 @@ _builtin_providers = [
             AuthParameter("redirect_path"),
             AuthParameter("required_scopes", str_to_list),
             AuthParameter("allowed_client_redirect_uris", str_to_list),
-            AuthParameter(
-                "require_authorization_consent", str_to_bool_or_external
-            ),
+            AuthParameter("require_authorization_consent", str_to_bool_or_external),
             AuthParameter("consent_csp_policy"),
             AuthParameter("forward_resource", str_to_bool),
         ],
@@ -222,9 +221,7 @@ _builtin_providers = [
             AuthParameter("redirect_path"),
             AuthParameter("additional_authorize_scopes", str_to_list),
             AuthParameter("allowed_client_redirect_uris", str_to_list),
-            AuthParameter(
-                "require_authorization_consent", str_to_bool_or_external
-            ),
+            AuthParameter("require_authorization_consent", str_to_bool_or_external),
             AuthParameter("consent_csp_policy"),
             AuthParameter("forward_resource", str_to_bool),
             AuthParameter("base_authority"),
@@ -246,9 +243,7 @@ _builtin_providers = [
             AuthParameter("valid_scopes", str_to_list),
             AuthParameter("timeout_seconds", str_to_int),
             AuthParameter("allowed_client_redirect_uris", str_to_list),
-            AuthParameter(
-                "require_authorization_consent", str_to_bool_or_external
-            ),
+            AuthParameter("require_authorization_consent", str_to_bool_or_external),
             AuthParameter("consent_csp_policy"),
             AuthParameter("forward_resource", str_to_bool),
             AuthParameter("extra_authorize_params", str_to_dict),
@@ -302,10 +297,7 @@ def _get_generic_provider_map() -> dict[str, AuthProviderInfo]:
     Indexes all known providers by their names as they would apper in the
     FASTMCP_SERVER_AUTH envar.
     """
-    return {
-        provider_name(provider): provider
-        for provider in _generic_providers
-    }
+    return {provider_name(provider): provider for provider in _generic_providers}
 
 
 @cache

--- a/exasol/ai/mcp/server/setup/generic_auth.py
+++ b/exasol/ai/mcp/server/setup/generic_auth.py
@@ -27,7 +27,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
 from io import StringIO
-from typing import Any
+from typing import Any, Literal
 
 from fastmcp.server.auth import (
     AuthProvider,
@@ -35,10 +35,16 @@ from fastmcp.server.auth import (
     RemoteAuthProvider,
 )
 from fastmcp.server.auth.auth import TokenVerifier
+from fastmcp.server.auth.providers.auth0 import Auth0Provider
+from fastmcp.server.auth.providers.aws import AWSCognitoProvider
+from fastmcp.server.auth.providers.azure import AzureProvider
 from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+from fastmcp.server.auth.providers.google import GoogleProvider
 from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.auth.providers.workos import AuthKitProvider
 
 ENV_PROVIDER_TYPE = "FASTMCP_SERVER_AUTH"
+_EXA_ENV_PREFIX = "EXA_AUTH_"
 
 
 def str_to_list(s) -> list[str]:
@@ -64,6 +70,13 @@ def str_to_bool(s) -> bool:
     raise ValueError(f"Invalid boolean parameter: {s}")
 
 
+def str_to_bool_or_external(s) -> bool | Literal["external"]:
+    s_lower = str_to_str(s).lower()
+    if s_lower == "external":
+        return "external"
+    return str_to_bool(s)
+
+
 def str_to_int(s: str) -> int:
     return int(str_to_str(s))
 
@@ -82,12 +95,15 @@ def str_to_dict(s) -> dict[str, str]:
 class AuthParameter:
     name: str
     conv: Callable[[str], Any] = lambda v: str_to_str(v)
+    env_name: str | None = None
 
 
 @dataclass
 class AuthProviderInfo:
     provider_type: type[AuthProvider]
     parameters: list[AuthParameter]
+    provider_name: str | None = None
+    env_prefix: str = _EXA_ENV_PREFIX
 
 
 _generic_providers = [
@@ -145,9 +161,130 @@ _generic_providers = [
     ),
 ]
 
+_builtin_providers = [
+    AuthProviderInfo(
+        provider_type=Auth0Provider,
+        provider_name="fastmcp.server.auth.providers.auth0.Auth0Provider",
+        env_prefix="FASTMCP_SERVER_AUTH_AUTH0_",
+        parameters=[
+            AuthParameter("config_url"),
+            AuthParameter("client_id"),
+            AuthParameter("client_secret"),
+            AuthParameter("audience"),
+            AuthParameter("base_url"),
+            AuthParameter("resource_base_url"),
+            AuthParameter("issuer_url"),
+            AuthParameter("required_scopes", str_to_list),
+            AuthParameter("redirect_path"),
+            AuthParameter("allowed_client_redirect_uris", str_to_list),
+            AuthParameter(
+                "require_authorization_consent", str_to_bool_or_external
+            ),
+            AuthParameter("consent_csp_policy"),
+            AuthParameter("forward_resource", str_to_bool),
+        ],
+    ),
+    AuthProviderInfo(
+        provider_type=AWSCognitoProvider,
+        provider_name="fastmcp.server.auth.providers.aws.AWSCognitoProvider",
+        env_prefix="FASTMCP_SERVER_AUTH_AWS_COGNITO_",
+        parameters=[
+            AuthParameter("user_pool_id"),
+            AuthParameter("aws_region"),
+            AuthParameter("client_id"),
+            AuthParameter("client_secret"),
+            AuthParameter("base_url"),
+            AuthParameter("resource_base_url"),
+            AuthParameter("issuer_url"),
+            AuthParameter("redirect_path"),
+            AuthParameter("required_scopes", str_to_list),
+            AuthParameter("allowed_client_redirect_uris", str_to_list),
+            AuthParameter(
+                "require_authorization_consent", str_to_bool_or_external
+            ),
+            AuthParameter("consent_csp_policy"),
+            AuthParameter("forward_resource", str_to_bool),
+        ],
+    ),
+    AuthProviderInfo(
+        provider_type=AzureProvider,
+        provider_name="fastmcp.server.auth.providers.azure.AzureProvider",
+        env_prefix="FASTMCP_SERVER_AUTH_AZURE_",
+        parameters=[
+            AuthParameter("client_id"),
+            AuthParameter("client_secret"),
+            AuthParameter("tenant_id"),
+            AuthParameter("required_scopes", str_to_list),
+            AuthParameter("base_url"),
+            AuthParameter("resource_base_url"),
+            AuthParameter("identifier_uri"),
+            AuthParameter("issuer_url"),
+            AuthParameter("redirect_path"),
+            AuthParameter("additional_authorize_scopes", str_to_list),
+            AuthParameter("allowed_client_redirect_uris", str_to_list),
+            AuthParameter(
+                "require_authorization_consent", str_to_bool_or_external
+            ),
+            AuthParameter("consent_csp_policy"),
+            AuthParameter("forward_resource", str_to_bool),
+            AuthParameter("base_authority"),
+            AuthParameter("enable_cimd", str_to_bool),
+        ],
+    ),
+    AuthProviderInfo(
+        provider_type=GoogleProvider,
+        provider_name="fastmcp.server.auth.providers.google.GoogleProvider",
+        env_prefix="FASTMCP_SERVER_AUTH_GOOGLE_",
+        parameters=[
+            AuthParameter("client_id"),
+            AuthParameter("client_secret"),
+            AuthParameter("base_url"),
+            AuthParameter("resource_base_url"),
+            AuthParameter("issuer_url"),
+            AuthParameter("redirect_path"),
+            AuthParameter("required_scopes", str_to_list),
+            AuthParameter("valid_scopes", str_to_list),
+            AuthParameter("timeout_seconds", str_to_int),
+            AuthParameter("allowed_client_redirect_uris", str_to_list),
+            AuthParameter(
+                "require_authorization_consent", str_to_bool_or_external
+            ),
+            AuthParameter("consent_csp_policy"),
+            AuthParameter("forward_resource", str_to_bool),
+            AuthParameter("extra_authorize_params", str_to_dict),
+            AuthParameter("enable_cimd", str_to_bool),
+        ],
+    ),
+    AuthProviderInfo(
+        provider_type=AuthKitProvider,
+        provider_name="fastmcp.server.auth.providers.workos.AuthKitProvider",
+        env_prefix="FASTMCP_SERVER_AUTH_AUTHKITPROVIDER_",
+        parameters=[
+            AuthParameter("authkit_domain"),
+            AuthParameter("base_url"),
+            AuthParameter("resource_base_url"),
+            AuthParameter("required_scopes", str_to_list),
+            AuthParameter("scopes_supported", str_to_list),
+            AuthParameter("resource_name"),
+            AuthParameter("resource_documentation"),
+        ],
+    ),
+]
+
 
 def exa_provider_name(provider_type: type[AuthProvider]) -> str:
     return f"exa.{provider_type.__module__}.{provider_type.__qualname__}"
+
+
+def provider_name(provider_info: AuthProviderInfo) -> str:
+    if provider_info.provider_name is not None:
+        return provider_info.provider_name
+    return exa_provider_name(provider_info.provider_type)
+
+
+def parameter_env_name(provider_info: AuthProviderInfo, param: AuthParameter) -> str:
+    env_name = param.env_name if param.env_name is not None else param.name.upper()
+    return f"{provider_info.env_prefix}{env_name}"
 
 
 def exa_parameter_env_name(param: AuthParameter) -> str:
@@ -155,19 +292,25 @@ def exa_parameter_env_name(param: AuthParameter) -> str:
     # this can potentially create a name clash between the parameters of JWTVerifier
     # and either OAuthProxy or RemoteAuthProvider. This is very unlikely though,
     # and we will deal with if and when it happens.
-    return f"EXA_AUTH_{param.name.upper()}"
+    env_name = param.env_name if param.env_name is not None else param.name.upper()
+    return f"{_EXA_ENV_PREFIX}{env_name}"
 
 
 @cache
-def _get_provider_map() -> dict[str, AuthProviderInfo]:
+def _get_generic_provider_map() -> dict[str, AuthProviderInfo]:
     """
     Indexes all known providers by their names as they would apper in the
     FASTMCP_SERVER_AUTH envar.
     """
     return {
-        exa_provider_name(provider.provider_type): provider
+        provider_name(provider): provider
         for provider in _generic_providers
     }
+
+
+@cache
+def _get_builtin_provider_map() -> dict[str, AuthProviderInfo]:
+    return {provider_name(provider): provider for provider in _builtin_providers}
 
 
 @cache
@@ -176,8 +319,9 @@ def _get_verifier_map() -> dict[str, AuthProviderInfo]:
     Indexes all known Token Verifiers by their names.
     """
     return {
-        exa_provider_name(ver_type): ver_type
-        for ver_type in [JWTVerifier, IntrospectionTokenVerifier]
+        provider_name(ver_type): ver_type
+        for ver_type in _generic_providers
+        if issubclass(ver_type.provider_type, TokenVerifier)
     }
 
 
@@ -185,9 +329,9 @@ def create_auth_provider(
     provider_info: AuthProviderInfo, **extra_kwargs
 ) -> AuthProvider:
     kwargs = {
-        param.name: param.conv(os.environ[exa_parameter_env_name(param)])
+        param.name: param.conv(os.environ[parameter_env_name(provider_info, param)])
         for param in provider_info.parameters
-        if exa_parameter_env_name(param) in os.environ
+        if parameter_env_name(provider_info, param) in os.environ
     }
     return provider_info.provider_type(**kwargs, **extra_kwargs)
 
@@ -221,10 +365,10 @@ def get_token_verifier(provider_name: str) -> tuple[TokenVerifier, str]:
     """
 
     # First check if the requested Auth provider is one of the Token Verifier types:
-    provider_map = _get_provider_map()
+    provider_map = _get_generic_provider_map()
     verifier_map = _get_verifier_map()
-    provider_type = verifier_map.get(provider_name)
-    if provider_type is not None:
+    verifier_type = verifier_map.get(provider_name)
+    if verifier_type is not None:
         provider = _try_create_auth_provider(provider_map[provider_name])
         return provider, provider_name
 
@@ -252,14 +396,20 @@ def get_auth_provider() -> AuthProvider | None:
     if not provider_name:
         return None
 
-    provider_map = _get_provider_map()
-    if provider_name not in provider_map:
+    generic_provider_map = _get_generic_provider_map()
+    if provider_name in generic_provider_map:
+        verifier, verifier_name = get_token_verifier(provider_name)
+        if provider_name == verifier_name:
+            return verifier
+        return create_auth_provider(
+            generic_provider_map[provider_name], token_verifier=verifier
+        )
+
+    builtin_provider_map = _get_builtin_provider_map()
+    if provider_name not in builtin_provider_map:
         return None
 
-    verifier, verifier_name = get_token_verifier(provider_name)
-    if provider_name == verifier_name:
-        return verifier
-    return create_auth_provider(provider_map[provider_name], token_verifier=verifier)
+    return _try_create_auth_provider(builtin_provider_map[provider_name])
 
 
 def get_auth_kwargs() -> dict[str, AuthProvider]:

--- a/test/unit/settings/test_generic_auth.py
+++ b/test/unit/settings/test_generic_auth.py
@@ -4,9 +4,9 @@ from fastmcp.server.auth import (
     OAuthProxy,
     RemoteAuthProvider,
 )
+from fastmcp.server.auth.oauth_proxy import proxy as oauth_proxy_module
 from fastmcp.server.auth.oidc_proxy import OIDCConfiguration
 from fastmcp.server.auth.oidc_proxy import OIDCProxy as FastMCPOIDCProxy
-from fastmcp.server.auth.oauth_proxy import proxy as oauth_proxy_module
 from fastmcp.server.auth.providers.auth0 import Auth0Provider
 from fastmcp.server.auth.providers.aws import AWSCognitoProvider
 from fastmcp.server.auth.providers.azure import AzureProvider

--- a/test/unit/settings/test_generic_auth.py
+++ b/test/unit/settings/test_generic_auth.py
@@ -4,9 +4,16 @@ from fastmcp.server.auth import (
     OAuthProxy,
     RemoteAuthProvider,
 )
+from fastmcp.server.auth.oidc_proxy import OIDCConfiguration
+from fastmcp.server.auth.oidc_proxy import OIDCProxy as FastMCPOIDCProxy
 from fastmcp.server.auth.oauth_proxy import proxy as oauth_proxy_module
+from fastmcp.server.auth.providers.auth0 import Auth0Provider
+from fastmcp.server.auth.providers.aws import AWSCognitoProvider
+from fastmcp.server.auth.providers.azure import AzureProvider
+from fastmcp.server.auth.providers.google import GoogleProvider
 from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
 from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.auth.providers.workos import AuthKitProvider
 
 from exasol.ai.mcp.server.setup.generic_auth import (
     ENV_PROVIDER_TYPE,
@@ -18,7 +25,9 @@ from exasol.ai.mcp.server.setup.generic_auth import (
     get_auth_kwargs,
     get_auth_provider,
     get_token_verifier,
+    parameter_env_name,
     str_to_bool,
+    str_to_bool_or_external,
     str_to_dict,
     str_to_int,
     str_to_list,
@@ -77,6 +86,14 @@ def test_str_to_bool_error():
 
 
 @pytest.mark.parametrize(
+    ["input_str", "expected_value"],
+    [(" true ", True), (" false ", False), (" external ", "external")],
+)
+def test_str_to_bool_or_external(input_str, expected_value):
+    assert str_to_bool_or_external(input_str) == expected_value
+
+
+@pytest.mark.parametrize(
     ["input_str", "expected_int"],
     [
         (" 5 ", 5),
@@ -128,6 +145,18 @@ def test_exa_provider_name() -> None:
 
 def test_exa_parameter_env_name() -> None:
     assert exa_parameter_env_name(AuthParameter("abc")) == "EXA_AUTH_ABC"
+
+
+def test_fastmcp_parameter_env_name() -> None:
+    provider_info = AuthProviderInfo(
+        provider_type=GoogleProvider,
+        provider_name="fastmcp.server.auth.providers.google.GoogleProvider",
+        env_prefix="FASTMCP_SERVER_AUTH_GOOGLE_",
+        parameters=[],
+    )
+    assert parameter_env_name(provider_info, AuthParameter("client_id")) == (
+        "FASTMCP_SERVER_AUTH_GOOGLE_CLIENT_ID"
+    )
 
 
 @pytest.mark.parametrize(
@@ -268,6 +297,131 @@ def test_get_auth_provider(monkeypatch, provider_type, params, tmp_path) -> None
 def test_get_auth_provider_error(monkeypatch) -> None:
     monkeypatch.setenv(ENV_PROVIDER_TYPE, "exa.non_existent_provider")
     assert get_auth_provider() is None
+
+
+@pytest.fixture
+def oidc_config() -> OIDCConfiguration:
+    return OIDCConfiguration.model_validate(
+        {
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://issuer.example.com/token",
+            "jwks_uri": "https://issuer.example.com/jwks",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
+    )
+
+
+@pytest.fixture
+def patch_oidc(monkeypatch, oidc_config):
+    monkeypatch.setattr(
+        FastMCPOIDCProxy,
+        "get_oidc_configuration",
+        staticmethod(lambda config_url, strict=None, timeout_seconds=None: oidc_config),
+    )
+
+
+_FASTMCP_PROVIDER_SELECTORS = {
+    GoogleProvider: "fastmcp.server.auth.providers.google.GoogleProvider",
+    AzureProvider: "fastmcp.server.auth.providers.azure.AzureProvider",
+    AuthKitProvider: "fastmcp.server.auth.providers.workos.AuthKitProvider",
+    Auth0Provider: "fastmcp.server.auth.providers.auth0.Auth0Provider",
+    AWSCognitoProvider: "fastmcp.server.auth.providers.aws.AWSCognitoProvider",
+}
+
+_FASTMCP_ENV_PREFIXES = {
+    GoogleProvider: "FASTMCP_SERVER_AUTH_GOOGLE_",
+    AzureProvider: "FASTMCP_SERVER_AUTH_AZURE_",
+    AuthKitProvider: "FASTMCP_SERVER_AUTH_AUTHKITPROVIDER_",
+    Auth0Provider: "FASTMCP_SERVER_AUTH_AUTH0_",
+    AWSCognitoProvider: "FASTMCP_SERVER_AUTH_AWS_COGNITO_",
+}
+
+
+@pytest.mark.parametrize(
+    ["provider_type", "params"],
+    [
+        (
+            GoogleProvider,
+            {
+                "client_id": "google-client",
+                "client_secret": "google-secret",
+                "base_url": "https://server.example.com",
+                "required_scopes": "openid,email",
+                "timeout_seconds": "12",
+                "extra_authorize_params": "access_type, offline, prompt, consent",
+                "enable_cimd": "false",
+            },
+        ),
+        (
+            AzureProvider,
+            {
+                "client_id": "azure-client",
+                "client_secret": "azure-secret",
+                "tenant_id": "azure-tenant",
+                "required_scopes": "read",
+                "base_url": "https://server.example.com",
+                "additional_authorize_scopes": "openid,profile",
+                "enable_cimd": "false",
+                "require_authorization_consent": "external",
+            },
+        ),
+        (
+            AuthKitProvider,
+            {
+                "authkit_domain": "https://tenant.authkit.app",
+                "base_url": "https://server.example.com",
+                "required_scopes": "openid,profile,email",
+            },
+        ),
+        (
+            Auth0Provider,
+            {
+                "config_url": "https://auth.example.com/.well-known/openid-configuration",
+                "client_id": "auth0-client",
+                "client_secret": "auth0-secret",
+                "audience": "https://api.example.com",
+                "base_url": "https://server.example.com",
+                "required_scopes": "openid,email",
+                "allowed_client_redirect_uris": "http://localhost:3000/*,https://app.example.com/*",
+                "require_authorization_consent": "external",
+                "forward_resource": "false",
+            },
+        ),
+        (
+            AWSCognitoProvider,
+            {
+                "user_pool_id": "eu-central-1_abc123",
+                "aws_region": "eu-central-1",
+                "client_id": "aws-client",
+                "client_secret": "aws-secret",
+                "base_url": "https://server.example.com",
+                "required_scopes": "openid,email",
+                "forward_resource": "false",
+            },
+        ),
+    ],
+    ids=["Google", "Azure", "AuthKit", "Auth0", "AWSCognito"],
+)
+def test_get_auth_provider_fastmcp_v2_envs(
+    monkeypatch, provider_type, params, tmp_path, patch_oidc
+) -> None:
+    provider_info = AuthProviderInfo(
+        provider_type=provider_type,
+        provider_name=_FASTMCP_PROVIDER_SELECTORS[provider_type],
+        env_prefix=_FASTMCP_ENV_PREFIXES[provider_type],
+        parameters=[],
+    )
+    monkeypatch.setenv(ENV_PROVIDER_TYPE, _FASTMCP_PROVIDER_SELECTORS[provider_type])
+    monkeypatch.setattr(oauth_proxy_module.settings, "home", tmp_path)
+
+    for key, value in params.items():
+        monkeypatch.setenv(parameter_env_name(provider_info, AuthParameter(key)), value)
+
+    provider = get_auth_provider()
+    assert isinstance(provider, provider_type)
 
 
 def test_get_auth_kwargs(monkeypatch) -> None:


### PR DESCRIPTION
Fixes #200 

## Summary
- restore FastMCP v2-style environment variable configuration for Auth0, AWS Cognito, Azure, Google, and AuthKit providers
- keep existing generic  provider handling intact while extending the auth loader for built-in FastMCP providers
- add unit coverage for provider env parsing and update the OpenID setup docs

## Testing
- poetry run pytest test/unit/settings/test_generic_auth.py